### PR TITLE
ObtainProductInfo returns an error if the product list is empty

### DIFF
--- a/Assets/Huawei/Scripts/IAP/UnityPurchase/HuaweiStore.cs
+++ b/Assets/Huawei/Scripts/IAP/UnityPurchase/HuaweiStore.cs
@@ -101,6 +101,12 @@ namespace HmsPlugin
 
         private void CreateProductRequest(List<string> consumablesIDs, HuaweiConstants.IAP.IapType type, System.Action onSuccess)
         {
+            if (consumablesIDs.Count == 0)
+            {
+                onSuccess();
+                return;
+            }
+
             var productsDataRequest        = new ProductInfoReq();
             productsDataRequest.PriceType  = (int)type;
             productsDataRequest.ProductIds = consumablesIDs;


### PR DESCRIPTION
If an empty product list is sent to ObtainProductInfo then an error is returned.  This pull request checks the length of the products list before sending the request and calls onSuccess() if it's empty.  This will allow games that don't have subscriptions to use HuaweiStore.