### PR TITLE
Using Huawei's localized price string

### DIFF
--- a/Assets/Huawei/Scripts/IAP/UnityPurchase/HuaweiStore.cs
+++ b/Assets/Huawei/Scripts/IAP/UnityPurchase/HuaweiStore.cs
@@ -169,13 +169,8 @@ namespace HmsPlugin
 
             foreach(var product in this.productsList)
             {
-                string priceString;
-                float price     = product.MicrosPrice * 0.000001f;
-
-                if (price < 100) priceString = price.ToString("0.00");
-                else             priceString = ((int)(price + 0.5f)).ToString();
-
-                var prodMeta = new ProductMetadata(priceString, product.ProductName, product.ProductDesc, product.Currency, (decimal)price);
+                float price = product.MicrosPrice * 0.000001f;
+                var prodMeta = new ProductMetadata(product.Price, product.ProductName, product.ProductDesc, product.Currency, (decimal)price);
                 ProductDescription prodDesc;
 
                 if(this.purchasedData.TryGetValue(product.ProductId, out var purchaseData))


### PR DESCRIPTION
This pull request uses the localized price string provided by Huawei instead of generating its own.  This should provide more consistency across currencies.  If a programmer still wants to generate their own price they can do so via the `ProductMetadata.localizedPrice` property.