### PR TITLE
Add purchase details to OnPurchaseSucceeded callback.

### DIFF
--- a/Assets/Huawei/Scripts/IAP/UnityPurchase/HuaweiStore.cs
+++ b/Assets/Huawei/Scripts/IAP/UnityPurchase/HuaweiStore.cs
@@ -243,13 +243,17 @@ namespace HmsPlugin
             {   
                 PurchaseResultInfo purchaseResultInfo = iapClient.ParsePurchaseResultInfoFromIntent(androidIntent);
 
+                var receipt = new PurchaseReceipt {
+                    signature=purchaseResultInfo.InAppDataSignature,
+                    json=purchaseResultInfo.InAppPurchaseData
+                };
 
                 switch (purchaseResultInfo.ReturnCode)
                 {
                     case OrderStatusCode.ORDER_STATE_SUCCESS:
                         var data = new InAppPurchaseData(purchaseResultInfo.InAppPurchaseData);
                         this.purchasedData[product.storeSpecificId] = data;
-                        storeEvents.OnPurchaseSucceeded(product.storeSpecificId, purchaseResultInfo.InAppDataSignature, data.OrderID );
+                        storeEvents.OnPurchaseSucceeded(product.storeSpecificId, UnityEngine.JsonUtility.ToJson(receipt), data.OrderID );
                         break;
 
                     case OrderStatusCode.ORDER_PRODUCT_OWNED:
@@ -292,7 +296,12 @@ namespace HmsPlugin
                 });
             }
         }
-        
+
+        internal class PurchaseReceipt
+        {
+            public string json;
+            public string signature;
+        }
     }
 }
 


### PR DESCRIPTION
Right now `HuaweiStore` returns nothing but the signature for a successful purchase on `OnPurchaseSucceeded` callback.  This throws away a lot of useful information about the purchase that the program may want.  This pull request sends all of the data (including signature) to `OnPurchaseSucceeded` as a json object.

This change may break programs that used the signature being sent by `OnPurchaseSucceeded`.  Older programs would need to change their code to support the json object instead of the signature string.  This shouldn't be too much effort as the signature is still contained within the payload.