### PR TITLE
Hotfixes

### DIFF
--- a/Assets/Huawei/Editor/Utils/HMSGradleWorker.cs
+++ b/Assets/Huawei/Editor/Utils/HMSGradleWorker.cs
@@ -34,7 +34,7 @@ namespace HmsPlugin
                 { AuthToggleEditor.AuthEnabled, new string[] { "com.huawei.agconnect:agconnect-auth:1.4.2.301" } },
                 { NearbyServiceToggleEditor.NearbyServiceEnabled, new string[] { "com.huawei.hms:nearby:5.3.0.300" } },
                 { AppMessagingToggleEditor.AppMessagingEnabled, new string[] { "com.huawei.agconnect:agconnect-appmessaging:1.4.2.301" } },
-                { HMSLibrariesDrawer.AppCompatEnabled,new string[]{ "com.android.support:appcompat-v7:28.0.0" } }
+                { HMSLibrariesDrawer.AppCompatEnabled,new string[]{ "com.android.support:appcompat-v7:21.0.0" } }
             };
         }
 

--- a/Assets/Huawei/Editor/View/LibrariesTab/HMSLibrariesDrawer.cs
+++ b/Assets/Huawei/Editor/View/LibrariesTab/HMSLibrariesDrawer.cs
@@ -19,7 +19,7 @@ namespace HmsPlugin
             _tabBar = tabBar;
             if (!HMSMainEditorSettings.Instance.Settings.HasKey(AppCompatEnabled)) 
                 HMSMainEditorSettings.Instance.Settings.SetBool(AppCompatEnabled, true);
-            _appSupportToggle = new Toggle.Toggle("App Compat (com.android.support:appcompat-v7:28.0.0)", HMSMainEditorSettings.Instance.Settings.GetBool(AppCompatEnabled, true), OnAppSupportToggleChanged, false).SetLabelWidth(350);
+            _appSupportToggle = new Toggle.Toggle("App Compat (com.android.support:appcompat-v7:21.0.0)", HMSMainEditorSettings.Instance.Settings.GetBool(AppCompatEnabled, true), OnAppSupportToggleChanged, false).SetLabelWidth(350);
         }
 
         private void OnAppSupportToggleChanged(bool value)

--- a/Assets/Huawei/Scripts/Ads/HMSAdsKitManager.cs
+++ b/Assets/Huawei/Scripts/Ads/HMSAdsKitManager.cs
@@ -105,6 +105,34 @@ public class HMSAdsKitManager : HMSSingleton<HMSAdsKitManager>
             bannerView.HideBanner();
     }
 
+    public void LoadBannerAd(string adId, UnityBannerAdPositionCodeType position, string bannerSize = UnityBannerAdSize.BANNER_SIZE_320_50)
+    {
+        if (!isInitialized || !adsKitSettings.GetBool(HMSAdsKitSettings.EnableBannerAd)) return;
+
+        Debug.Log("[HMS] HMSAdsKitManager Loading Banner Ad.");
+        var bannerAdStatusListener = new AdStatusListener();
+        bannerAdStatusListener.mOnAdLoaded += BannerAdStatusListener_mOnAdLoaded;
+        bannerAdStatusListener.mOnAdClosed += BannerAdStatusListener_mOnAdClosed;
+        bannerAdStatusListener.mOnAdImpression += BannerAdStatusListener_mOnAdImpression;
+        bannerAdStatusListener.mOnAdClicked += BannerAdStatusListener_mOnAdClicked;
+        bannerAdStatusListener.mOnAdOpened += BannerAdStatusListener_mOnAdOpened;
+        bannerAdStatusListener.mOnAdFailed += BannerAdStatusListener_mOnAdFailed;
+
+        bannerView = new BannerAd(bannerAdStatusListener);
+        bannerView.AdId = adId;
+        bannerView.PositionType = (int)position;
+        bannerView.SizeType = bannerSize;
+        bannerView.AdStatusListener = bannerAdStatusListener;
+        if (!string.IsNullOrEmpty(adsKitSettings.Get(HMSAdsKitSettings.BannerRefreshInterval)))
+            bannerView.BannerRefresh = long.Parse(adsKitSettings.Get(HMSAdsKitSettings.BannerRefreshInterval));
+        _isBannerAdLoaded = false;
+        bannerView.LoadBanner(new AdParam.Builder().Build());
+        if (adsKitSettings.GetBool(HMSAdsKitSettings.ShowBannerOnLoad))
+            bannerView.ShowBanner();
+        else
+            bannerView.HideBanner();
+    }
+
     public void ShowBannerAd()
     {
         if (bannerView == null)
@@ -210,6 +238,18 @@ public class HMSAdsKitManager : HMSSingleton<HMSAdsKitManager>
         interstitialView.LoadAd(new AdParam.Builder().Build());
     }
 
+    public void LoadInterstitialAd(string adId)
+    {
+        if (!isInitialized || !adsKitSettings.GetBool(HMSAdsKitSettings.EnableInterstitialAd)) return;
+        Debug.Log("[HMS] HMSAdsKitManager Loading Interstitial Ad.");
+        interstitialView = new InterstitialAd
+        {
+            AdId = adId,
+            AdListener = new InterstitialAdListener(this)
+        };
+        interstitialView.LoadAd(new AdParam.Builder().Build());
+    }
+
     public void ShowInterstitialAd()
     {
         Debug.Log("[HMS] HMSAdsKitManager ShowInterstitialAd called");
@@ -308,6 +348,15 @@ public class HMSAdsKitManager : HMSSingleton<HMSAdsKitManager>
         if (!isInitialized || !adsKitSettings.GetBool(HMSAdsKitSettings.EnableRewardedAd)) return;
         Debug.Log("[HMS] HMSAdsKitManager LoadRewardedAd");
         rewardedView = new RewardAd(adsKitSettings.GetBool(HMSAdsKitSettings.UseTestAds) ? TestRewardedAdId : adsKitSettings.Get(HMSAdsKitSettings.RewardedAdID));
+        rewardedView.RewardAdListener = new RewardAdListener(this);
+        rewardedView.LoadAd(new AdParam.Builder().Build());
+    }
+
+    public void LoadRewardedAd(string adId)
+    {
+        if (!isInitialized || !adsKitSettings.GetBool(HMSAdsKitSettings.EnableRewardedAd)) return;
+        Debug.Log("[HMS] HMSAdsKitManager LoadRewardedAd");
+        rewardedView = new RewardAd(adId);
         rewardedView.RewardAdListener = new RewardAdListener(this);
         rewardedView.LoadAd(new AdParam.Builder().Build());
     }


### PR DESCRIPTION
Downgraded AppCompat library to v7.21 version due to Avast finding v7.28 version as a virus.
Added Loading ads with AdId methods.