### PR TITLE
Hup 76 enable app signing warning message

### DIFF
--- a/Assets/Huawei/Editor/View/PublishingAPI/QueryingAppInformation/HelpBoxEnablingAppSigning.cs
+++ b/Assets/Huawei/Editor/View/PublishingAPI/QueryingAppInformation/HelpBoxEnablingAppSigning.cs
@@ -11,7 +11,7 @@ namespace HmsPlugin
 
         public HelpBoxEnablingApp()
         {
-            _helpBox = new HelpBox.HelpBox("Please Check the App Signing Enabled in the Huawei App Gallery", UnityEditor.MessageType.Error);
+            _helpBox = new HelpBox.HelpBox("Please Check the App Signing Feature Enabled on AppGallery Connect For Uploading AAB Packages", UnityEditor.MessageType.Error);
             isAABSelected = UnityEditor.EditorUserBuildSettings.buildAppBundle;
         }
 

--- a/Assets/Huawei/Editor/View/PublishingAPI/QueryingAppInformation/HelpBoxEnablingAppSigning.cs
+++ b/Assets/Huawei/Editor/View/PublishingAPI/QueryingAppInformation/HelpBoxEnablingAppSigning.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace HmsPlugin
+{
+    public class HelpBoxEnablingApp : IDrawer
+    {
+        private HelpBox.HelpBox _helpBox;
+        private bool isAABSelected;
+
+        public HelpBoxEnablingApp()
+        {
+            _helpBox = new HelpBox.HelpBox("Please Check the App Signing Enabled in the Huawei App Gallery", UnityEditor.MessageType.Error);
+            isAABSelected = UnityEditor.EditorUserBuildSettings.buildAppBundle;
+        }
+
+        public void Draw()
+        {
+            if (isAABSelected)
+            {
+                _helpBox.Draw();
+            }
+        }
+    }
+} 

--- a/Assets/Huawei/Editor/View/PublishingAPI/QueryingAppInformation/HelpBoxEnablingAppSigning.cs.meta
+++ b/Assets/Huawei/Editor/View/PublishingAPI/QueryingAppInformation/HelpBoxEnablingAppSigning.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6286a5c7eda0ac84581b41f69f117cdb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Huawei/Editor/View/PublishingAPI/QueryingAppInformation/QueryingAppInfoEditor.cs
+++ b/Assets/Huawei/Editor/View/PublishingAPI/QueryingAppInformation/QueryingAppInfoEditor.cs
@@ -45,6 +45,8 @@ namespace HmsPlugin.PublishingAPI
             AddDrawer(new HorizontalLine());
             AddDrawer(new HorizontalSequenceDrawer(uploadPackage, new Spacer()));
             AddDrawer(new Space(5));
+            AddDrawer(new HelpBoxEnablingApp());
+            AddDrawer(new Space(5));
 
             RequestAppInfo();
         }


### PR DESCRIPTION
If AAB selected and opened queryingAppInformation, a warning message comes and tells you to check app signing feature of agc