### PR TITLE
GradleFixer gradle version update

### DIFF
--- a/Assets/Huawei/Editor/Utils/HMSGradleFixer.cs
+++ b/Assets/Huawei/Editor/Utils/HMSGradleFixer.cs
@@ -24,7 +24,7 @@ public class HMSGradleFixer : IPostGenerateGradleAndroidProject
         Match gradleVersionMatch = Regex.Match(gradleRowMatch.Value, gradleVersionPattern);
         Version gradleVersion = Version.Parse(gradleVersionMatch.Value);
         // if users gradle version is lesser than our minimum version.
-        if (gradleVersion.CompareTo(gradleMinVersion) > 0)
+        if (gradleVersion.CompareTo(gradleMinVersion) < 0)
         {
             gradleFileAsString = gradleFileAsString.Replace(gradleVersion.ToString(), gradleMinVersion.ToString());
             File.WriteAllText(Directory.GetParent(path).FullName + "/build.gradle", gradleFileAsString);
@@ -58,7 +58,15 @@ public class HMSGradleFixer : IPostGenerateGradleAndroidProject
         string baseProjectTemplatePath = Application.dataPath + "/Huawei/Plugins/Android/hmsBaseProjectTemplate.gradle";
         FileUtil.CopyFileOrDirectory(baseProjectTemplatePath, Directory.GetParent(path).FullName + @"/hmsBaseProjectTemplate.gradle");
 
-        GradleVersionFixer(File.ReadAllText(Directory.GetParent(path).FullName + "/build.gradle"), path);
+        // Get enabled Kits and check if they are AdsKit or PushKit because only them needs to be updated to the latest version.
+        foreach (var toggle in HMSMainKitsTabFactory.GetEnabledEditors())
+        {
+            if (toggle.GetType() == typeof(AdsToggleEditor) 
+                || toggle.GetType() == typeof(PushToggleEditor))
+            {
+                GradleVersionFixer(File.ReadAllText(Directory.GetParent(path).FullName + "/build.gradle"), path);
+            }
+        }
 
         using (var writer = File.AppendText(Directory.GetParent(path).FullName + "/build.gradle"))
             writer.WriteLine("\napply from: 'hmsBaseProjectTemplate.gradle'");

--- a/Assets/Huawei/Editor/Utils/HMSGradleFixer.cs
+++ b/Assets/Huawei/Editor/Utils/HMSGradleFixer.cs
@@ -58,11 +58,14 @@ public class HMSGradleFixer : IPostGenerateGradleAndroidProject
         string baseProjectTemplatePath = Application.dataPath + "/Huawei/Plugins/Android/hmsBaseProjectTemplate.gradle";
         FileUtil.CopyFileOrDirectory(baseProjectTemplatePath, Directory.GetParent(path).FullName + @"/hmsBaseProjectTemplate.gradle");
 
-        // Get enabled Kits and check if they are AdsKit or PushKit because only them needs to be updated to the latest version.
+        // Get enabled Kits and check if they are one of the below, because only them needs to be updated to the latest version.
         foreach (var toggle in HMSMainKitsTabFactory.GetEnabledEditors())
         {
-            if (toggle.GetType() == typeof(AdsToggleEditor) 
-                || toggle.GetType() == typeof(PushToggleEditor))
+            if (toggle.GetType() == typeof(AccountToggleEditor) 
+                || toggle.GetType() == typeof(PushToggleEditor)
+                || toggle.GetType() == typeof(IAPToggleEditor)
+                || toggle.GetType() == typeof(NearbyServiceToggleEditor)
+                || toggle.GetType() == typeof(AnalyticsToggleEditor))
             {
                 GradleVersionFixer(File.ReadAllText(Directory.GetParent(path).FullName + "/build.gradle"), path);
             }

--- a/Assets/Huawei/Editor/Utils/HMSGradleFixer.cs
+++ b/Assets/Huawei/Editor/Utils/HMSGradleFixer.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEditor.Android;
 using UnityEngine;
@@ -11,6 +12,24 @@ using UnityEngine;
 public class HMSGradleFixer : IPostGenerateGradleAndroidProject
 {
     public int callbackOrder => 1;
+    private const string MINGRADLEVERSION = "3.5.4";
+
+    private void GradleVersionFixer(string gradleFileAsString, string path)
+    {
+        string gradleRowPattern = @".*gradle:(\d\.?)+";
+        string gradleVersionPattern = @"(\d\.?)+";
+        Version gradleMinVersion = Version.Parse(MINGRADLEVERSION);
+
+        Match gradleRowMatch = Regex.Match(gradleFileAsString, gradleRowPattern);
+        Match gradleVersionMatch = Regex.Match(gradleRowMatch.Value, gradleVersionPattern);
+        Version gradleVersion = Version.Parse(gradleVersionMatch.Value);
+        // if users gradle version is lesser than our minimum version.
+        if (gradleVersion.CompareTo(gradleMinVersion) > 0)
+        {
+            gradleFileAsString = gradleFileAsString.Replace(gradleVersion.ToString(), gradleMinVersion.ToString());
+            File.WriteAllText(Directory.GetParent(path).FullName + "/build.gradle", gradleFileAsString);
+        }
+    }
 
     public void OnPostGenerateGradleAndroidProject(string path)
     {
@@ -38,6 +57,9 @@ public class HMSGradleFixer : IPostGenerateGradleAndroidProject
 
         string baseProjectTemplatePath = Application.dataPath + "/Huawei/Plugins/Android/hmsBaseProjectTemplate.gradle";
         FileUtil.CopyFileOrDirectory(baseProjectTemplatePath, Directory.GetParent(path).FullName + @"/hmsBaseProjectTemplate.gradle");
+
+        GradleVersionFixer(File.ReadAllText(Directory.GetParent(path).FullName + "/build.gradle"), path);
+
         using (var writer = File.AppendText(Directory.GetParent(path).FullName + "/build.gradle"))
             writer.WriteLine("\napply from: 'hmsBaseProjectTemplate.gradle'");
 


### PR DESCRIPTION
Now minimum gradle version is 3.5.4. If user uses lesser than this version, GradleFixer is going to replace it with 3.5.4