### PR TITLE
Developed a "key tool" to the utils menu for quickly obtaining the SHA-256 key.

### DIFF
--- a/Assets/Huawei/Editor/View/KeyToolTab.meta
+++ b/Assets/Huawei/Editor/View/KeyToolTab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1b628a66912c9cc4586cc3686add6e3d
+guid: 74c56dc0090a1f24fa978c46c5a8161d
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Huawei/Editor/View/KeyToolTab/HMSKeyToolWindow.cs
+++ b/Assets/Huawei/Editor/View/KeyToolTab/HMSKeyToolWindow.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+public class HMSKeyToolWindow : EditorWindow
+{
+    #region Variables
+    private const string KeyToolHelpCommand = "-help";
+
+    // File and password information.
+    private string filePath = string.Empty;
+    private string password = string.Empty;
+    private string aliasPassword = string.Empty;
+    private List<string> aliases = new List<string>();
+    private int selectedAliasIndex = 0;
+
+    // Drag-and-drop state.
+    private bool isKeystoreDropped = false;
+
+    // SHA-256 result and command execution.
+    private string sha256 = string.Empty;
+    private bool isExecutable = false;
+
+    #endregion
+
+    void OnGUI()
+    {
+        GUILayout.Label("Key Tool Drag & Drop Tool", EditorStyles.boldLabel);
+        EditorGUILayout.Space();
+        EditorGUILayout.HelpBox("Drag and drop your keystore file below to generate SHA-256.", MessageType.Info);
+        EditorGUILayout.Space();
+
+        // Drag and drop area.
+        Rect dropArea = GUILayoutUtility.GetRect(0.0f, 50.0f, GUILayout.ExpandWidth(true));
+        GUI.Box(dropArea, "Drag & Drop Keystore File Here");
+        HandleDragAndDrop(dropArea);
+
+        if (isKeystoreDropped)
+        {
+            ShowPasswordField(ref password, "Keystore", ref isExecutable);
+            if (aliases.Count > 0)
+            {
+                ShowAliasSelection();
+                ShowPasswordField(ref aliasPassword, "Alias", ref isExecutable);
+            }
+            ShowActionButton();
+            ShowSHA256Result();
+        }
+    }
+    private void ShowPasswordField(ref string passwordField, string label, ref bool controlState)
+    {
+        EditorGUILayout.Space();
+        //GUILayout.Label(label);
+        string enteredPassword = EditorGUILayout.PasswordField(label + " Password", passwordField);
+
+        if (!string.IsNullOrWhiteSpace(enteredPassword))
+        {
+            passwordField = enteredPassword;
+            controlState = true;
+        }
+    }
+    private void ShowAliasSelection()
+    {
+        EditorGUILayout.Space();
+        GUILayout.Label("Select your alias:");
+        EditorGUI.BeginChangeCheck();
+        selectedAliasIndex = EditorGUILayout.Popup("Alias", selectedAliasIndex, aliases.ToArray());
+        if (EditorGUI.EndChangeCheck())
+        {
+            sha256 = string.Empty;
+            aliasPassword = string.Empty;
+        }
+    }
+    private void ShowActionButton()
+    {
+        if (isExecutable)
+        {
+            EditorGUILayout.Space();
+            string buttonName = aliases.Count > 0 ? "Obtain SHA-256" : "Run";
+            if (GUILayout.Button(buttonName))
+            {
+                ExecuteKeyTool();
+            }
+        }
+    }
+    private void ShowSHA256Result()
+    {
+        if (!string.IsNullOrWhiteSpace(sha256))
+        {
+            EditorGUILayout.Space();
+            GUILayout.Label("Selected File: " + Path.GetFileName(filePath));
+            EditorGUILayout.Space();
+            GUILayout.Label("Your SHA-256: \n" + sha256, EditorStyles.wordWrappedLabel);
+            EditorGUILayout.Space();
+            if (GUILayout.Button("Copy SHA-256 to Clipboard"))
+            {
+                GUIUtility.systemCopyBuffer = sha256;
+                EditorUtility.DisplayDialog("SHA-256 Copied", "The SHA-256 hash has been copied to clipboard.", "OK");
+            }
+        }
+    }
+    private void HandleDragAndDrop(Rect dropArea)
+    {
+        Event evt = Event.current;
+        if ((evt.type == EventType.DragUpdated || evt.type == EventType.DragPerform) && dropArea.Contains(evt.mousePosition))
+        {
+            DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
+#if UNITY_2019_3_OR_NEWER
+            if (evt is { type: EventType.DragPerform or EventType.DragUpdated })
+#elif UNITY_2018_1_OR_NEWER
+            if (evt.type == EventType.DragPerform || evt.type == EventType.DragUpdated)
+#endif
+            {
+                DragDropOperations();
+            }
+            else if (evt.type == EventType.DragExited)
+            {
+                DragAndDrop.PrepareStartDrag();
+            }
+            evt.Use();
+        }
+    }
+    private void DragDropOperations()
+    {
+        DragAndDrop.AcceptDrag();
+        DragAndDrop.activeControlID = GUIUtility.GetControlID(FocusType.Passive);
+
+        filePath = DragAndDrop.paths.FirstOrDefault() ?? string.Empty;
+        isKeystoreDropped = !string.IsNullOrWhiteSpace(filePath) && filePath.EndsWith(".keystore", StringComparison.OrdinalIgnoreCase);
+        if (!isKeystoreDropped)
+        {
+            EditorUtility.DisplayDialog("Invalid File", "Please drop a .keystore file.", "OK");
+        }
+        else
+        {
+            isExecutable = false;
+            sha256 = string.Empty;
+            aliases = new List<string>();
+            password = string.Empty;
+            aliasPassword = string.Empty;
+        }
+    }
+    private void ExecuteKeyTool()
+    {
+        // Check if KeyTool executable is available.
+        string keytoolPath = CheckKeyTool();
+        if (keytoolPath == "Keytool is not available.")
+        {
+            EditorUtility.DisplayDialog("Keytool Not Found", "Unable to find Keytool in your environment.", "OK");
+            return;
+        }
+
+        string arguments = $"-list -v -keystore \"{filePath}\" -storepass {password}";
+        if (aliases.Count > 0)
+        {
+            arguments += $" -keypass {aliasPassword} -alias {aliases[selectedAliasIndex]}";
+        }
+
+        // Start the KeyTool process.
+        ProcessStartInfo startInfo = new ProcessStartInfo
+        {
+            FileName = keytoolPath,
+            Arguments = arguments,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using (Process process = Process.Start(startInfo))
+        {
+            string output = process.StandardOutput.ReadToEnd();
+            string errorOutput = process.StandardError.ReadToEnd();
+#if UNITY_2019_3_OR_NEWER
+            var errorCheck = errorOutput.Contains("error", StringComparison.InvariantCultureIgnoreCase) || output.Contains("error", StringComparison.InvariantCultureIgnoreCase);
+#elif UNITY_2018_1_OR_NEWER
+            var errorCheck = errorOutput.ToLower().Contains("error") || output.ToLower().Contains("error");
+#endif
+
+            process.WaitForExit();
+
+            if (errorCheck)
+            {
+                string errorMessage = !string.IsNullOrWhiteSpace(errorOutput) ? errorOutput : output;
+
+                EditorUtility.DisplayDialog("Keytool Error", $"An error occurred: {errorMessage}", "OK");
+            }
+            else
+            {
+                if (aliases.Count > 0)
+                {
+                    sha256 = ExtractSHA256(output);
+                }
+                else
+                {
+                    aliases = GetAliasNames(output);
+                    if (aliases.Count == 0)
+                        EditorUtility.DisplayDialog("No Aliases Found", "No aliases found in the keystore file.", "OK");
+                }
+            }
+        }
+    }
+    private string ExtractSHA256(string input)
+    {
+        var match = Regex.Match(input, @"SHA-?256:\s*(\S+)");
+        return match.Success ? match.Groups[1].Value : null;
+    }
+    private List<string> GetAliasNames(string text)
+    {
+        return Regex.Matches(text, @"Alias name: (.+)")
+                    .Cast<Match>()
+                    .Select(m => m.Groups[1].Value.Trim())
+                    .ToList();
+    }
+    private string CheckKeyTool()
+    {
+        string keytoolPath = "keytool";
+        try
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = keytoolPath,
+                Arguments = KeyToolHelpCommand,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true
+            };
+
+            using (Process process = Process.Start(startInfo))
+            {
+                process.WaitForExit();
+            }
+
+            return keytoolPath;
+        }
+        catch (Exception)
+        {
+            //if windows
+            return Path.GetDirectoryName(Path.Combine(EditorApplication.applicationContentsPath, "PlaybackEngines\\AndroidPlayer\\OpenJDK\\bin\\keytool.exe\\")).Replace("\\", "/");
+        }
+    }
+}

--- a/Assets/Huawei/Editor/View/KeyToolTab/HMSKeyToolWindow.cs.meta
+++ b/Assets/Huawei/Editor/View/KeyToolTab/HMSKeyToolWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77c8496f77220e8498776502e79003ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Huawei/Editor/View/KeyToolUtils.meta
+++ b/Assets/Huawei/Editor/View/KeyToolUtils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1b628a66912c9cc4586cc3686add6e3d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Huawei/Editor/View/MainWindow/HMSMainWindow.cs
+++ b/Assets/Huawei/Editor/View/MainWindow/HMSMainWindow.cs
@@ -35,6 +35,12 @@ public class HMSMainWindow : HMSEditorWindow
         HMSEditorUtils.SetHMSPlugin(false, false);
     }
 
+    [MenuItem("Huawei/Utils/Key Tool")]
+    public static void KeyTool()
+    {
+       GetWindow(typeof(HMSKeyToolWindow), false, "HMS Key Tool", true);
+    }
+
     public override IDrawer CreateDrawer()
     {
         var tabBar = new TabBar();


### PR DESCRIPTION
This pull request adds a new feature called "Key Tool" to the utils menu. The "Key Tool" allows users to quickly obtain the SHA-256 key. It includes the following changes:

- Created a new file called KeyToolTab under the Editor/View directory.

- Added HMSKeyToolWindow.cs file for all key tool operations.

- Added a new menu item "Huawei/Utils/Key Tool" for accessing the key tool.

These changes enhance the functionality of the application by providing an easy way to obtain the SHA-256 key.