### PR TITLE
HUP-448 added ability to pass developerPayload string into each InAppPurchaseData thru PurchaseProduct method.

### DIFF
--- a/Assets/Huawei/Scripts/IAP/HMSIAPManager.cs
+++ b/Assets/Huawei/Scripts/IAP/HMSIAPManager.cs
@@ -26,7 +26,8 @@ namespace HmsPlugin
         public Action<HMSException> OnConsumePurchaseFailure { get; set; }
 
         public Action<PurchaseResultInfo> OnBuyProductSuccess { get; set; }
-        public Action<PurchaseResultInfo> OnBuyProductFailure { get; set; }
+        public Action<int> OnBuyProductFailure { get; set; }
+        public Action<PurchaseResultInfo> OnBuyProductFailurePurchaseResultInfo { get; set; }
 
         public Action<OwnedPurchasesResult> OnObtainOwnedPurchasesSuccess { get; set; }
         public Action<HMSException> OnObtainOwnedPurchasesFailure { get; set; }
@@ -489,6 +490,8 @@ namespace HmsPlugin
 
                         if(consume)
                             ConsumePurchase(purchaseResultInfo.InAppPurchaseData);
+                        else
+                            Debug.LogWarning($"[{Tag}]: Consume is false. Please aware of the situation. You should consume the product by your own. ProductID: {purchaseIntentReq.ProductId}");
                         /*if (sandboxState.SandboxUser)
                         {
                             if (isConsumable || isNonConsumable)
@@ -500,7 +503,6 @@ namespace HmsPlugin
                         {
                             ConsumePurchase(purchaseResultInfo.InAppPurchaseData);
                         }*/
-
                     }
                     else
                     {
@@ -591,7 +593,8 @@ namespace HmsPlugin
                                 Debug.LogError($"[{Tag}]: BuyProduct failed. ReturnCode: " + purchaseResultInfo.ReturnCode + ", ErrorMsg: " + purchaseResultInfo.ErrMsg);
                                 break;
                         }
-                        OnBuyProductFailure?.Invoke(purchaseResultInfo);
+                        OnBuyProductFailure?.Invoke(purchaseResultInfo.ReturnCode);
+                        OnBuyProductFailurePurchaseResultInfo?.Invoke(purchaseResultInfo);
                     }
 
                 }, (exception) =>

--- a/Assets/Huawei/Scripts/IAP/HMSIAPManager.cs
+++ b/Assets/Huawei/Scripts/IAP/HMSIAPManager.cs
@@ -26,7 +26,7 @@ namespace HmsPlugin
         public Action<HMSException> OnConsumePurchaseFailure { get; set; }
 
         public Action<PurchaseResultInfo> OnBuyProductSuccess { get; set; }
-        public Action<int> OnBuyProductFailure { get; set; }
+        public Action<PurchaseResultInfo> OnBuyProductFailure { get; set; }
 
         public Action<OwnedPurchasesResult> OnObtainOwnedPurchasesSuccess { get; set; }
         public Action<HMSException> OnObtainOwnedPurchasesFailure { get; set; }
@@ -429,7 +429,7 @@ namespace HmsPlugin
 
         #region Purchase
 
-        public void PurchaseProduct(string productId, bool consume = true)
+        public void PurchaseProduct(string productId, string developerPayload = "", bool consume = true)
         {
             Debug.Log($"[{Tag}]: PurchaseProduct");
 
@@ -437,7 +437,7 @@ namespace HmsPlugin
 
             if (productInfo != null)
             {
-                PurchaseProductMethod(productInfo, consume);
+                PurchaseProductMethod(productInfo, developerPayload, consume);
             }
             else
             {
@@ -445,7 +445,7 @@ namespace HmsPlugin
             }
         }
 
-        private void PurchaseProductMethod(ProductInfo productInfo, bool consume)
+        private void PurchaseProductMethod(ProductInfo productInfo, string developerPayload, bool consume)
         {
             Debug.Log($"[{Tag}]: PurchaseProductMethod");
 
@@ -459,7 +459,7 @@ namespace HmsPlugin
             {
                 PriceType = productInfo.PriceType,
                 ProductId = productInfo.ProductId,
-                DeveloperPayload = string.Empty
+                DeveloperPayload = developerPayload,
             };
 
             bool isSubscription = (IAPProductType)productInfo.PriceType.Value == IAPProductType.Subscription;
@@ -591,7 +591,7 @@ namespace HmsPlugin
                                 Debug.LogError($"[{Tag}]: BuyProduct failed. ReturnCode: " + purchaseResultInfo.ReturnCode + ", ErrorMsg: " + purchaseResultInfo.ErrMsg);
                                 break;
                         }
-                        OnBuyProductFailure?.Invoke(purchaseResultInfo.ReturnCode);
+                        OnBuyProductFailure?.Invoke(purchaseResultInfo);
                     }
 
                 }, (exception) =>


### PR DESCRIPTION
`OnBuyProductFailure` should works with `PurchaseResultInfo` because `developerPayload` needs even purchase has been failed.