### PR TITLE
When ad removal is purchased, a structure has been added to prevent H…

### DIFF
--- a/Assets/Huawei/Demos/Ads/AdsDemoManager.cs
+++ b/Assets/Huawei/Demos/Ads/AdsDemoManager.cs
@@ -32,16 +32,17 @@ public class AdsDemoManager : MonoBehaviour
 
     private void Start()
     {
-        HMSAdsKitManager.Instance.OnRewarded = OnRewarded;
-        HMSAdsKitManager.Instance.OnInterstitialAdClosed = OnInterstitialAdClosed;
-
-        HMSAdsKitManager.Instance.ConsentOnFail = OnConsentFail;
-        HMSAdsKitManager.Instance.ConsentOnSuccess = OnConsentSuccess;
+        HMSAdsKitManager.Instance = new HMSAdsKitManager(hasPurchasedNoAds: false)
+        {
+            OnRewarded = OnRewarded,
+            OnInterstitialAdClosed = OnInterstitialAdClosed,
+            ConsentOnFail = OnConsentFail,
+            ConsentOnSuccess = OnConsentSuccess
+        };
         HMSAdsKitManager.Instance.RequestConsentUpdate();
 
         //testAdStatusToggle = GameObject.FindGameObjectWithTag("Toggle").GetComponent<Toggle>();
         //testAdStatusToggle.isOn = HMSAdsKitSettings.Instance.Settings.GetBool(HMSAdsKitSettings.UseTestAds);
-        
 
         #region SetNonPersonalizedAd , SetRequestLocation
 
@@ -59,7 +60,6 @@ public class AdsDemoManager : MonoBehaviour
         Debug.Log($"{TAG}Consent: {requestOptions.Consent}");
 
         #endregion
-
     }
 
     private void OnConsentSuccess(ConsentStatus consentStatus, bool isNeedConsent, IList<AdProvider> adProviders)

--- a/Assets/Huawei/Scripts/Utils/HMSSingleton.cs
+++ b/Assets/Huawei/Scripts/Utils/HMSSingleton.cs
@@ -42,9 +42,10 @@ public class HMSEditorSingleton<T> where T : new()
         }
     }
 }
+
 public class HMSManagerSingleton<T> where T : new()
 {
-    private static readonly Lazy<T> _instance = new Lazy<T>(() => new T());
+    private static Lazy<T> _instance = new Lazy<T>(() => new T());
 
     public static T Instance
     {
@@ -52,5 +53,6 @@ public class HMSManagerSingleton<T> where T : new()
         {
             return _instance.Value;
         }
+        set => _instance = new Lazy<T>(() => value);
     }
 }


### PR DESCRIPTION
…MSAdsKitManager from showing ads by transferring a boolean when creating the Instance.

* When ad removal is purchased, a structure has been added to prevent HMSAdsKitManager from showing ads by transferring a boolean when creating the Instance.
* SplashAd now checks when loading to see if ad removal has been purchased.