### PR TITLE
#496 disable HMSPluginUpdater on Microsoft Xbox, Sony Playstation 4/5 and Nintendo Switch

### DIFF
--- a/Assets/Huawei/Editor/Utils/HMSPluginUpdater.cs
+++ b/Assets/Huawei/Editor/Utils/HMSPluginUpdater.cs
@@ -13,9 +13,26 @@ namespace HmsPlugin
         public static string sessionState = "hms_checked_update";
 
         static HMSPluginUpdateRequest request;
+        
+        static bool ignorePlatform
+        {
+            get
+            {
+#if UNITY_SWITCH || UNITY_GAMECORE || UNITY_PS4 || UNITY_PS5
+                return true;
+#else
+                return false;
+#endif
+            }
+        }
 
         internal static void Request(bool ignoreSession = false)
         {
+            if (ignorePlatform)
+            {
+                return;
+            }
+            
             if (!ignoreSession && SessionState.GetBool(sessionState, false))
             {
                 return;


### PR DESCRIPTION
fixed issue in https://github.com/EvilMindDevs/hms-unity-plugin/issues/469